### PR TITLE
CHANGE enqueue the PP js in the admin so that we’re able to localize them in the future

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -33,64 +33,103 @@ if ( ! defined('ABSPATH') ) { exit; }
 
 if ( $prettypress_config['enabled'] == "enabled" ) {
 	//Register our hooks.
-	
+
 	//The CSS.
 	add_action( 'admin_enqueue_scripts', 'prettypress_css_hook' );
-	
+
 	//The meta box
 	add_action( 'add_meta_boxes', 'prettypress_meta_box' );
-	
+
 	//The page hooks.
 	add_action( 'edit_form_after_editor', 'prettypress_edit_hook' );
 	add_action( 'edit_page_form', 'prettypress_edit_hook' );
-	
+
+	// Load the JS appropriately
+	add_action( 'admin_enqueue_scripts', 'prettypress_enqueue_scripts' );
+
 	//The live page hooks
 	add_filter( 'the_content', 'prettypress_thecontent' );
 	add_filter( 'the_title', 'prettypress_thetitle' );
-	
+
 	//Autosave for posts that don't have a post ID yet.
 	add_filter('redirect_post_location', 'prettypress_autosave');
-	
-	
+
+
 } else {
 	//PrettyPress is disabled.
 	//Go outside and play!
 }
 
 
- 
+
 function prettypress_autosave( $location ) {
-	
+
 	global $post;
 
 	//Make sure we are saving.
 	if (! empty($_POST['save']) ) {
-		
+
 		//Make sure it's a draft.
 		if ( $_POST['save'] == "Save Draft" ) {
-			
+
 			if (! empty($_POST['prettypress_active']) ) {
-				
+
 				//We know for sure that this post save was triggered by PrettyPress.
 				//We are safe to assume that a PrettyPress auto-launch has been triggered.
 				$location .= "&prettypress_active=1";
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	return $location;
- 
+
 }
 
 function prettypress_edit_hook() {
 
 	//Include the primary edit page on "edit" entries.
 	require_once PLUGINPATH . '/view/edit.php';
-	
+
 }
+
+/**
+ * Load the PP js in the back end
+ *
+ * @author Richard Tape <@richardtape>
+ * @package PrettyPress
+ * @since 0.4
+ * @param (string) $hook - the hook name of the currently active screen
+ * @return null
+ */
+
+function prettypress_enqueue_scripts( $hook ){
+
+	// Array of screens where we want to load our JS
+	$allowedHooks = array(
+		'post.php',
+		'post-new.php'
+	);
+
+	// Run the hooks through a filter so we can modify this externally
+	$allowedHooks = apply_filters( 'prettypress_allowed_hooks_for_js_load', $allowedHooks, $hook );
+
+	// Check that we still have hooks to show on
+	if( !is_array( $allowedHooks ) || empty( $allowedHooks ) )
+		return;
+
+	if( !in_array( $hook, array_values( $allowedHooks ) ) )
+		return;
+
+	// OK we're on the right screen, let's load these guys. Should perhaps use plugin_dir_url() rather than constant
+	wp_enqueue_script( 'prettypress_js_main', 		PRETTYPRESS_BASE_URL . '/assets/js/prettypress.js' );
+	wp_enqueue_script( 'prettypress_js_hooks', 		PRETTYPRESS_BASE_URL . '/assets/js/prettypress_hooks.js' );
+	wp_enqueue_script( 'prettypress_js_resize', 	PRETTYPRESS_BASE_URL . '/assets/js/prettypress_resize.js' );
+	wp_enqueue_script( 'prettypress_js_bootloader', PRETTYPRESS_BASE_URL . '/assets/js/prettypress_bootloader.js' );
+
+}/* prettypress_enqueue_scripts */
 
 function prettypress_css_hook() {
 
@@ -104,34 +143,58 @@ function prettypress_css_hook() {
 		wp_register_style( 'prettypress_css_legacy', PRETTYPRESS_BASE_URL . "/assets/css/prettypress-legacy.css", false );
 		wp_enqueue_style( 'prettypress_css_legacy' );
 	}
-	
-	
+
+
 }
 
 function prettypress_meta_box() {
 
-	//Register the meta boxes for all post types.
-	//It should be possible to register all three with one call.
-	//Fix this.
-	
-	add_meta_box( 'prettypress_meta_hwnd', __( 'PrettyPress', 'prfx-textdomain' ), 'prettypress_meta_hwnd_callback', 'post', 'side', 'high' );
-	add_meta_box( 'prettypress_meta_hwnd', __( 'PrettyPress', 'prfx-textdomain' ), 'prettypress_meta_hwnd_callback', 'page', 'side', 'high' );
-	add_meta_box( 'prettypress_meta_hwnd', __( 'PrettyPress', 'prfx-textdomain' ), 'prettypress_meta_hwnd_callback', 'custom', 'side', 'high' );
-	
+	// start fresh for an array of post types we want to register PP on
+	$registerOn = array();
+
+	// Add posts and pages by default
+	$registerOn[] = 'post';
+	$registerOn[] = 'page';
+
+	// We also want to automatically add all custom post types
+	$args = array(
+		'public'   => true,
+		'_builtin' => false
+	);
+
+	$publicCPTs = get_post_types( $args, 'names', 'and' );
+
+	if( is_array( $publicCPTs && !empty( $publicCPTs ) ) )
+		foreach( $publicCPTs as $key => $cptName )
+			$registerOn[] = $cptName;
+
+	// Run it through a filter so we can amend this elsehwere
+	$registerOn = apply_filters( 'prettypress_post_types_to_show_metabox', $registerOn );
+
+	// Also have a filter for the location and priority so we're not forcing this
+	$location = apply_filters( 'prettypress_metabox_location', 'side' );
+	$priority = apply_filters( 'prettypress_metabox_priority', 'high' );
+
+	if( !is_array( $registerOn ) || empty( $registerOn ) )
+		return;
+
+	foreach( $registerOn as $key => $cptName )
+		add_meta_box( 'prettypress_meta_hwnd', __( 'PrettyPress', 'prfx-textdomain' ), 'prettypress_meta_hwnd_callback', $cptName, $location, $priority );
+
 }
 
 function prettypress_meta_hwnd_callback( $post ) {
 
 	//Include the metabox page.
 	require_once PLUGINPATH . '/view/metabox.php';
-	
+
 }
 
 function prettypress_thecontent( $content ) {
 
 	//We're yet to find a circumstance where we shouldn't automatically
 	//filter the_content (except for guest viewers).
-	
+
 	if ( is_user_logged_in() ) {
 		return '<span data-rel="content">' . $content . '</span>';
 	} else {
@@ -150,7 +213,7 @@ function prettypress_thetitle( $title ) {
 	//This should be refined further
 	//See http://codex.wordpress.org/Conditional_Tags
 	//Fix this
-	
+
 	if ( is_user_logged_in() && $id ) {
 		if ( is_admin() ) {
 			global $pagenow;
@@ -165,7 +228,7 @@ function prettypress_thetitle( $title ) {
 	} else {
 		return $title;
 	}
-	
+
 }
 
 ?>

--- a/view/edit.php
+++ b/view/edit.php
@@ -44,12 +44,12 @@ global $post;
 
 <div class="prettypress_wrapper" id="prettypress_wrapper">
 	<div class="prettypress_resize" id="resize"><div class="border"></div></div>
-	
+
 	<div class="prettypress_nav wp-ui-primary wp-ui-core wp-submenu" id="prettypress_menu">
 		<div class="item item-left" id="prettypress_exit"></div>
 		<div class="item-left">Back to Wordpress</div>
 	</div>
-	
+
 	<div class="prettypress_preview_container" id="prettypress_preview_container">
 		<iframe id="prettypress_iframe" class="prettypress_iframe" src=""></iframe>
 	</div>
@@ -62,8 +62,3 @@ global $post;
 	<input type="hidden" id="prettypress_autoload" value="1" />
 	<?php }	?>
 </div>
-
-<script src="<?php echo PRETTYPRESS_BASE_URL; ?>/assets/js/prettypress.js"></script>
-<script src="<?php echo PRETTYPRESS_BASE_URL; ?>/assets/js/prettypress_hooks.js"></script>
-<script src="<?php echo PRETTYPRESS_BASE_URL; ?>/assets/js/prettypress_resize.js"></script>
-<script src="<?php echo PRETTYPRESS_BASE_URL; ?>/assets/js/prettypress_bootloader.js"></script>


### PR DESCRIPTION
Instead of directly injecting script tags into the edit screens, we load them via wp_enqueue_scripts this affords us several things such as: ability to dequeue them externally, ability to enqueue items before/after them, easier versioning and, importantly, the ability to easily localize these scripts.

My main reasoning behind this was to have a way to pass PHP data to the javascript with relative ease (often done via wp_localize_script) so that it's possible for the JS to know which custom fields to fetch. As there are several different methods custom meta can be added (and manipulated) to a post (core/standard post meta, Advanced Custom Fields, or other plugins) we need the JS to be aware of where to fetch the custom meta from, so I was considering having a filter which people can add to so they can register support for custom fields to the PP edit screen (i.e. the LHS of the split window)

Either way, it's better practice to load JS via this method.
## Notes

CHANGE enqueue the PP js in the admin so that we’re able to localize them in the future
REMOVE the direct loading of the scripts
ADD filter for which pages (hook slugs) the scripts are loaded on
CHANGE remove some stray whitespace (auto by ST2 plugin)
