### PR TITLE
Fixed Quick Edit bug, fixed quotes conflict bug

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -201,13 +201,13 @@ function prettypress_thetitle( $title ) {
 	if ( is_user_logged_in() && $id ) {
 		if ( is_admin() ) {
 			global $pagenow;
-			if ( $pagenow != 'edit.php' && $pagenow != "upload.php" ) {
-				return '<span data-rel="title">' . $title . '</span>';
+			if ( $pagenow != 'edit.php' && $pagenow != "upload.php" && $pagenow != "admin-ajax.php" ) {
+				return '<span data-rel=title>' . $title . '</span>';
 			} else {
 				return $title;
 			}
 		} else {
-			return '<span data-rel="title">' . $title . '</span>';
+			return '<span data-rel=title>' . $title . '</span>';
 		}
 	} else {
 		return $title;


### PR DESCRIPTION
1. Quick edit bug: after using quick edit to update post, it would display like this

![01](https://cloud.githubusercontent.com/assets/3773015/4623930/e8f84e7a-5358-11e4-93e0-3f57a3c90e28.png)
1. quotes conflict bug: if the post link format is `<a href="link" title="title">title</a>`, it would display like `<a href="link" title="<span class="title">title</span>">tile</a>` 
